### PR TITLE
Potential fix for code scanning alert no. 18: Database query built from user-controlled sources

### DIFF
--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -130,7 +130,19 @@ router.put("/:id", recipeWriteLimiter, async (req, res) => {
   const update = {};
   for (const key of allowedFields) {
     if (req.body[key] !== undefined) {
-      update[key] = req.body[key];
+      // Only allow primitive values for update fields
+      const value = req.body[key];
+      // For now, treat strings and numbers (adjust as needed for schema)
+      if (
+        typeof value === "string" ||
+        typeof value === "number" ||
+        typeof value === "boolean" ||
+        (Array.isArray(value) && key === "ingredients") // ingredients could be an array
+      ) {
+        update[key] = value;
+      } else {
+        return res.status(400).json({ msg: `Invalid value for field "${key}"` });
+      }
     }
   }
   try {


### PR DESCRIPTION
Potential fix for [https://github.com/shrutikarne/recipe-share/security/code-scanning/18](https://github.com/shrutikarne/recipe-share/security/code-scanning/18)

To fix this vulnerability, we should validate that all values copied from `req.body` for each allowed field are primitives (not objects or arrays with potential query operators). Strict type checks (e.g., typeof for string, number, boolean; Array.isArray for arrays) for each field should be implemented in the assignment loop (lines 131-135). If a field expects a primitive, ensure that the user-provided value is not an object, especially not containing `$`-prefixed operators. Insert an explicit check in the loop or, more strictly, use Mongoose’s schema validation, but given only this code is shown, we'll do the validation in this snippet.

Specifically:  
- After checking `req.body[key] !== undefined`, confirm with `typeof req.body[key] !== "object" || req.body[key] === null || Array.isArray(req.body[key])` (for arrays) or stricter if the field is supposed to be a primitive.
- If an object is supplied where not expected, reject the request with a 400 error.

No new imports are needed. The changes are all within the loop (lines 131-135) and possibly a helper function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
